### PR TITLE
caching w/ chrome ext storage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "name": "__MSG_appName__",
+  "name": "gh-interactions",
   "version": "1.0.0",
   "minimum_chrome_version": "72",
   "manifest_version": 2,
-  "description": "__MSG_appDescription__",
+  "description": "gh interactions is cool",
   "background": {
     "scripts": [
       "scripts/GitHub.bundle.js",
@@ -13,7 +13,7 @@
   },
   "permissions": [
     "activeTab",
-    "debugger",
+    "unlimitedStorage",
     "storage"
   ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'none'"

--- a/src/scripts/background-entry.js
+++ b/src/scripts/background-entry.js
@@ -1,6 +1,6 @@
 // basic auth
 const gh = new GitHub({
-  username: '___USERNAME___',
+  username: 'egsweeny',
   token: '___TOKEN___',
 });
 const search = gh.search();
@@ -80,7 +80,7 @@ async function findCommonInteractions(otherUsername) {
 }
 
 (async function() {
-  console.log('common', await findCommonInteractions('paulirish'));
+  console.log('common', await findCommonInteractions('peixotorms'));
 })();
 
 


### PR DESCRIPTION
the interactions collection takes like 1 minute and is 500k for `paulirish`

now the result is cached locally.

the cache invalidation/updating is still TBD



also i changed the users to folks that had a common interaction but otherwise doesnt take much time.
but feel free to revert [that one](https://github.com/connorjclark/gh-interactions/commit/7c3a583883ebacad53ff3cbc9cb600e2531fba11).